### PR TITLE
Fix cancel permission and CSRF check

### DIFF
--- a/mypage/application_cancel.php
+++ b/mypage/application_cancel.php
@@ -2,8 +2,13 @@
 include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
 include $_SERVER['DOCUMENT_ROOT'] . '/inc/util_lib.inc';
 
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('잘못된 접근입니다.');
+}
+
 $idx = isset($_POST['idx']) ? (int) $_POST['idx'] : 0;
 $tableKey = $_POST['table'] ?? '';
+$token = $_POST['csrf_token'] ?? '';
 
 $tableMap = [
     'application' => 'df_site_application_registration',
@@ -11,15 +16,24 @@ $tableMap = [
     'competition' => 'df_site_competition_registration',
 ];
 
-if ($idx <= 0 || !isset($tableMap[$tableKey])) {
+if (
+    $idx <= 0 ||
+    !isset($tableMap[$tableKey]) ||
+    $token !== ($_SESSION['csrf_token'] ?? '')
+) {
     error('잘못된 접근입니다.');
 }
 
 $table = $tableMap[$tableKey];
-$row   = $db->row("SELECT f_applicant_status FROM {$table} WHERE idx=:idx", ['idx' => $idx]);
+$row   = $db->row("SELECT f_user_id, f_applicant_status FROM {$table} WHERE idx=:idx", ['idx' => $idx]);
+$loginId = $_SESSION['kbga_user_id'] ?? '';
 
 if (!$row) {
     error('신청 정보를 찾을 수 없습니다.');
+}
+
+if ($row['f_user_id'] !== $loginId) {
+    error('잘못된 접근입니다.');
 }
 
 if ($row['f_applicant_status'] === 'ing') {


### PR DESCRIPTION
## Summary
- restrict cancel requests to logged-in owner
- validate csrf token on cancel

## Testing
- `php -l mypage/application_cancel.php`


------
https://chatgpt.com/codex/tasks/task_e_687078f6187c8322af9edfaeb61a82ee